### PR TITLE
Update requirements.txt to remove torch version constraint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-torch==1.9.0
+torch
 gym3
 attrs
 opencv-python


### PR DESCRIPTION
I've noticed a fixed constraint in the `requirements.txt` file specifying `torch==1.9.0`. However, I'm using Python 3.10 and CUDA 11.5, which is incompatible with torch 1.9.0. When I ran `pip install -r requirements.txt`, I encountered the following error:
```
ERROR: Could not find a version that satisfies the requirement torch==1.9.0 (from versions: 1.11.0, 1.12.0, 1.12.1, 1.13.0, 1.13.1, 2.0.0, 2.0.1, 2.1.0, 2.1.1, 2.1.2, 2.2.0, 2.2.1)
ERROR: No matching distribution found for torch==1.9.0
```
Therefore, I manually installed the latest version of torch (2.2.1), and it works perfectly. Perhaps the constraint on the torch version is unnecessary. Removing the specific version constraint would allow users to install the latest compatible version.