### PR TITLE
Update README.md: Fix typo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ pip install git+https://github.com/minerllabs/minerl
 pip install -r requirements.txt
 ```
 
-> ⚠️ Note: For reproducibility reasons, the PyTorch version is pinned as `torch==1.9.0`, which is incompatible with Python 3.10 or higher versions. If you are using Python 3.10 or higher, install a [newer version of PyTorch](https://>pytorch.org/get-started/locally/) (usually, `pip install torch`). However, note that this *might* subtly change model behaviour (e.g., still act mostly as expected, but not reaching the reported performance).
+> ⚠️ Note: For reproducibility reasons, the PyTorch version is pinned as `torch==1.9.0`, which is incompatible with Python 3.10 or higher versions. If you are using Python 3.10 or higher, install a [newer version of PyTorch](https://pytorch.org/get-started/locally/) (usually, `pip install torch`). However, note that this *might* subtly change model behaviour (e.g., still act mostly as expected, but not reaching the reported performance).
 
 To run the code, call
 


### PR DESCRIPTION
There is a typo that broke the PyTorch URL.